### PR TITLE
cleaned up the subcommand structure of the CLI to allow for better er…

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,26 @@ use std::str::FromStr;
 
 use std::path::Path;
 
-use clap::Parser;
+use clap::{Args, Parser, Subcommand};
 
 mod file;
 mod translate;
 
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[command(author, version, about, long_about=None)]
-struct Args {
+#[command(propagate_version = true)]
+struct CLI {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    Translate(TranslateArgs),
+}
+
+#[derive(Args)]
+struct TranslateArgs {
     #[arg(short, long, default_value = "strings/strings_en.json")]
     path: Option<String>,
 
@@ -23,65 +35,69 @@ struct Args {
 }
 
 fn main() {
-    let args = Args::parse();
+    let cli = CLI::parse();
 
-    let source_path = args.path.unwrap();
-    if !(Path::new(&source_path).exists()) {
-        println!("Provided filepath does not exist");
-        return;
-    }
+    match &cli.command {
+        Commands::Translate(args) => {
+            let source_path = args.path.as_ref().unwrap();
+            if !(Path::new(&source_path).exists()) {
+                println!("Provided filepath does not exist");
+                return;
+            }
 
-    let target_language_argument = args.target_language.unwrap();
-    let target_file_path = format!("strings/strings_{}.json", target_language_argument);
+            let target_language_argument = args.target_language.as_ref().unwrap();
+            let target_file_path = format!("strings/strings_{}.json", target_language_argument);
 
-    let target_language = match translate::ValidTargetLanguages::from_str(&target_language_argument)
-    {
-        Ok(language) => language,
-        Err(error) => {
-            println!("target language not supported{}", error);
-            return;
+            let target_language =
+                match translate::ValidTargetLanguages::from_str(&target_language_argument) {
+                    Ok(language) => language,
+                    Err(error) => {
+                        println!("target language not supported{}", error);
+                        return;
+                    }
+                };
+            let source_language = translate::ValidSourceLanguages::en;
+
+            let json = match file::get_json(source_path.to_string()) {
+                Ok(json) => json,
+                Err(error) => {
+                    println!("Error reading json file: {}", error);
+                    return;
+                }
+            };
+
+            let mut destination_hash_map: HashMap<String, file::Key> = HashMap::new();
+
+            for (key, value) in json.iter() {
+                let request = translate::TranslationRequest {
+                    text: value.string.clone(),
+                    from_language: source_language,
+                    to_language: target_language,
+                };
+                let translation_result = translate::translate_string(request);
+                println!("{:?}", translation_result);
+                destination_hash_map.insert(
+                    key.clone(),
+                    file::Key {
+                        string: translation_result.unwrap().text,
+                        example_keys: None,
+                    },
+                );
+            }
+            let target_file = target_file_path.to_string();
+            let json = match serde_json::to_string_pretty(&destination_hash_map) {
+                Ok(json) => json,
+                Err(error) => {
+                    println!("Internat Error converting json to string: {}", error);
+                    return;
+                }
+            };
+
+            let success = fs::write(target_file, json);
+            match success {
+                Ok(_) => println!("Successfully wrote to file"),
+                Err(error) => println!("Error writing to file: {}", error),
+            }
         }
-    };
-    let source_language = translate::ValidSourceLanguages::en;
-
-    let json = match file::get_json(source_path) {
-        Ok(json) => json,
-        Err(error) => {
-            println!("Error reading json file: {}", error);
-            return;
-        }
-    };
-
-    let mut destination_hash_map: HashMap<String, file::Key> = HashMap::new();
-
-    for (key, value) in json.iter() {
-        let request = translate::TranslationRequest {
-            text: value.string.clone(),
-            from_language: source_language,
-            to_language: target_language,
-        };
-        let translation_result = translate::translate_string(request);
-        println!("{:?}", translation_result);
-        destination_hash_map.insert(
-            key.clone(),
-            file::Key {
-                string: translation_result.unwrap().text,
-                example_keys: None,
-            },
-        );
-    }
-    let target_file = target_file_path.to_string();
-    let json = match serde_json::to_string_pretty(&destination_hash_map) {
-        Ok(json) => json,
-        Err(error) => {
-            println!("Internat Error converting json to string: {}", error);
-            return;
-        }
-    };
-
-    let success = fs::write(target_file, json);
-    match success {
-        Ok(_) => println!("Successfully wrote to file"),
-        Err(error) => println!("Error writing to file: {}", error),
     }
 }


### PR DESCRIPTION
Your comment about the unclear error message left me thinking I should probably clean that behavior up. 

Now usage of the tool is behind a subcommand `translate`. i.e.: `spake-cli translate --args`.
Calling the tool with no arguments will now correctly spit out a basic usage instructions. 

``` 
kiran@Kiran's MBP spake-cli-redux % spake-cli
Usage: spake-cli <COMMAND>

Commands:
  translate
  help       Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help information
  -V, --version  Print version information
kiran@Kiran's MBP spake-cli-redux %
```