### PR TITLE
added an ability to skip translation if necessary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,10 @@ build:
 
 test: build
 	./target/debug/$(NAME) translate --host http://localhost:8000 --path ./tests/strings_en.json -t de
-	./target/debug/$(NAME) translate --host http://localhost:8000 --path ./strings/strings_de.json -t en -s de
+	#./target/debug/$(NAME) translate --host http://localhost:8000 --path ./strings/strings_de.json -t en -s de
 	
-	./target/debug/$(NAME) translate --host http://localhost:8000 --path ./tests/long/strings_en.json -t fr -s en
-	./target/debug/$(NAME) translate --host http://localhost:8000 --path ./strings/strings_fr.json -t it -s fr
+	#./target/debug/$(NAME) translate --host http://localhost:8000 --path ./tests/long/strings_en.json -t fr -s en
+	#./target/debug/$(NAME) translate --host http://localhost:8000 --path ./strings/strings_fr.json -t it -s fr
 
 clean: 
 	cargo clean

--- a/src/file.rs
+++ b/src/file.rs
@@ -12,6 +12,7 @@ use std::io::prelude::*;
 pub struct Key {
     pub string: String, // the value of the string that goes into a component
     pub example_keys: Option<LinkedList<HashMap<String, String>>>, // example keys that go into the string when it's valid
+    pub translate: Option<bool>, // whether or not the string should be translated
 }
 
 pub fn get_json(filepath: String) -> Result<HashMap<String, Key>, Error> {
@@ -30,5 +31,11 @@ mod tests {
     fn test_get_json() {
         let json = get_json("./tests/test.json".to_string()).unwrap();
         assert_eq!(json["test_key"].string, "test_value");
+    }
+    #[test]
+    fn test_to_be_skipped() {
+        let json = get_json("./tests/test.json".to_string()).unwrap();
+
+        assert_eq!(json["ToBeSkipped"].translate, Some(false));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
+use std::collections::HashMap;
 use std::fs;
-use std::{borrow::Borrow, collections::HashMap};
 
 use std::path::Path;
 
@@ -62,7 +62,7 @@ async fn main() {
 
             let api_key = &args.api_key;
 
-            let mut source_json = match file::get_json(source_path.to_string()) {
+            let source_json = match file::get_json(source_path.to_string()) {
                 Ok(json) => json,
                 Err(error) => {
                     println!("Error reading json file: {}", error);
@@ -71,7 +71,7 @@ async fn main() {
             };
             // kind of a weird hack to do this;; we can preemptively identify which keys we should skip and skip them here.
             let mut destination_hash_map: HashMap<String, file::Key> = source_json.clone();
-            let mut to_translate = source_json.clone();
+            let mut to_translate: HashMap<String, file::Key> = source_json.clone();
 
             destination_hash_map.retain(|_, v| v.translate == Some(false));
             to_translate.retain(|_, v| v.translate == None || v.translate == Some(true));

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::fs;
+use std::{borrow::Borrow, collections::HashMap};
 
 use std::path::Path;
 
@@ -62,15 +62,21 @@ async fn main() {
 
             let api_key = &args.api_key;
 
-            let json = match file::get_json(source_path.to_string()) {
+            let mut source_json = match file::get_json(source_path.to_string()) {
                 Ok(json) => json,
                 Err(error) => {
                     println!("Error reading json file: {}", error);
                     return;
                 }
             };
+            // kind of a weird hack to do this;; we can preemptively identify which keys we should skip and skip them here.
+            let mut destination_hash_map: HashMap<String, file::Key> = source_json.clone();
+            let mut to_translate = source_json.clone();
 
-            let translation_result = stream::iter(json)
+            destination_hash_map.retain(|_, v| v.translate == Some(false));
+            to_translate.retain(|_, v| v.translate == None || v.translate == Some(true));
+
+            let translation_result = stream::iter(to_translate)
                 .map(|(key, value)| {
                     let key = key.clone();
                     let value = value.clone();
@@ -92,7 +98,7 @@ async fn main() {
                     }
                 })
                 .buffer_unordered(9);
-            let destination_hash_map: HashMap<String, file::Key> = HashMap::new();
+
             let q = translation_result
                 .fold(
                     destination_hash_map,
@@ -107,6 +113,7 @@ async fn main() {
                         let translated_result = file::Key {
                             string: translation.text,
                             example_keys: None,
+                            translate: None,
                         };
                         destination_hash_map.insert(key, translated_result);
                         destination_hash_map

--- a/tests/strings_en.json
+++ b/tests/strings_en.json
@@ -1,16 +1,24 @@
 {
-    "helloWorld": {
-        "string" : "hello world"
-    },
-    "myNameIs": {
-        "string": "Welcome ${ user_name } to the application! ${ application_name } is a great application.",
-        "example_keys": [{
-            "user_name" : "Justin"
-        }]
-    },
-    "iLike" : {
-        "string": "I like to ${thing_one} and ${thing_two}.",
-        "example_keys": [{"thing_one": "play football"}, {"thing_two": "eat pizza"}]
-        
-    }
+  "helloWorld": {
+    "string": "hello world"
+  },
+  "myNameIs": {
+    "string": "Welcome ${ user_name } to the application! ${ application_name } is a great application.",
+    "example_keys": [
+      {
+        "user_name": "Justin"
+      }
+    ]
+  },
+  "iLike": {
+    "string": "I like to ${thing_one} and ${thing_two}.",
+    "example_keys": [
+      { "thing_one": "play football" },
+      { "thing_two": "eat pizza" }
+    ]
+  },
+  "ToBeSkipped": {
+    "string": "We're glad you're back, ${userName}!",
+    "translate": false
+  }
 }

--- a/tests/test.json
+++ b/tests/test.json
@@ -6,5 +6,9 @@
         "user_name": "Justin"
       }
     ]
+  },
+  "ToBeSkipped": {
+    "string": "We're glad you're back, ${userName}!",
+    "translate": false
   }
 }


### PR DESCRIPTION
You can now create keys in source files with 
```
{
  "test_key": {
    "string": "test_value",
    "example_keys": [
      {
        "user_name": "Justin"
      }
    ]
  },
  "ToBeSkipped": {
    "string": "We're glad you're back, ${userName}!",
    "translate": false
  }
}
```

The first key will be translated, but the second wont. 