### PR TITLE
Spake cli init

### DIFF
--- a/src/gather/extractor.rs
+++ b/src/gather/extractor.rs
@@ -56,7 +56,7 @@ pub fn replace_raw_strings_in_file(file_path: &str, strings_file_path: &str) -> 
     for (k, v) in component_map.iter() {
         new_src = new_src.replace(k, v);
     }
-    fs::write(file_path, new_src);
+    let _ = fs::write(file_path, new_src);
     // rebuild the file from the components.
     return "new_src".to_string();
 }
@@ -66,7 +66,7 @@ fn add_key_to_strings_file(new_key: String, text_data: String, strings_file_path
     let mut keys = match keys {
         Ok(k) => k,
         Err(_) => {
-            println!("There was anerror reading in the keys file");
+            println!("There was an error reading in the keys file");
             return;
         }
     };
@@ -87,7 +87,7 @@ fn add_key_to_strings_file(new_key: String, text_data: String, strings_file_path
             return;
         }
     };
-    fs::write(strings_file_path, json);
+    let _ = fs::write(strings_file_path, json);
 }
 
 fn position_tag_iterator_to_string(
@@ -217,8 +217,8 @@ fn extract_returned_jsx_from_component(component: &str) -> Option<&str> {
                 return Some(capture.get(0).unwrap().as_str());
             }
         }
-        Err(_) => {
-            panic!("error)")
+        Err(err) => {
+            panic!("error, {:?}, {:?}", err, component)
         }
     }
     None

--- a/src/main.rs
+++ b/src/main.rs
@@ -242,8 +242,6 @@ async fn main() {
 
                 let _ = fs::create_dir_all(strings_folder_string);
                 let _ = fs::File::create(full_path);
-
-                println!("if you're reading this i forgot to remove a debug statement");
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ use clap::{Args, Parser, Subcommand};
 
 use futures::{stream, StreamExt};
 
+use fancy_regex::Regex;
 use std::ffi::OsStr;
 use walkdir::WalkDir;
 
@@ -197,11 +198,52 @@ async fn main() {
 
                 println!("Gathering strings");
             }
-            Beta::Init(_) => {
+            Beta::Init(args) => {
                 // Init should create the appropriate strings folder and the base json file.
                 // it should have an optional parameter for doing the gather step too.
 
-                println!("Not Implemented yet. Coming soon!");
+                let full_path = Path::new(args.base_path.as_ref().unwrap());
+                let strings_folder = full_path.parent();
+                let strings_folder_string: &str;
+
+                match strings_folder {
+                    Some(parent_path) => strings_folder_string = parent_path.to_str().unwrap(),
+                    None => {
+                        println!("Error creating strings folder. Folder name is Bogus.");
+                        return;
+                    }
+                }
+                // start validate filename block
+                let file_name = full_path.file_name();
+                let file_name_string: &str;
+                match file_name {
+                    Some(file_name) => file_name_string = file_name.to_str().unwrap(),
+                    None => {
+                        println!("Error validating string name. FileName is bogus.");
+                        return;
+                    }
+                }
+                //
+                let re = Regex::new(r"^strings_[A-Za-z]{2}\.json$").unwrap();
+                let matches = re.is_match(file_name_string);
+                match matches {
+                    Ok(is_valid) => {
+                        if !is_valid {
+                            println!("Error validating target strings name, {:?} does not conform to standard strings file format.", file_name_string);
+                            return;
+                        }
+                    }
+                    Err(_) => {
+                        println!("Error validating strings name. Input is so garbage it breaks the regex module somehow.");
+                        return;
+                    }
+                }
+                // end valdiate filename block
+
+                let _ = fs::create_dir_all(strings_folder_string);
+                let _ = fs::File::create(full_path);
+
+                println!("if you're reading this i forgot to remove a debug statement");
             }
         },
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -205,7 +205,7 @@ async fn main() {
                 let full_path = Path::new(args.base_path.as_ref().unwrap());
                 let strings_folder = full_path.parent();
                 let strings_folder_string: &str;
-
+                // create strings folder
                 match strings_folder {
                     Some(parent_path) => strings_folder_string = parent_path.to_str().unwrap(),
                     None => {
@@ -213,7 +213,8 @@ async fn main() {
                         return;
                     }
                 }
-                // start validate filename block
+
+                // validate file name
                 let file_name = full_path.file_name();
                 let file_name_string: &str;
                 match file_name {
@@ -223,7 +224,7 @@ async fn main() {
                         return;
                     }
                 }
-                //
+
                 let re = Regex::new(r"^strings_[A-Za-z]{2}\.json$").unwrap();
                 let matches = re.is_match(file_name_string);
                 match matches {
@@ -238,7 +239,6 @@ async fn main() {
                         return;
                     }
                 }
-                // end valdiate filename block
 
                 let _ = fs::create_dir_all(strings_folder_string);
                 let _ = fs::File::create(full_path);


### PR DESCRIPTION
Super basic work up of a new endpoint I had meant to add last month but didn't get to it. 

This is meant to establish users initial state with the strings folder system. So a user could get started with spake simply with 
```
spake-cli beta init 
spake-cli beta gather
```

In a future ticket I would like to also add an init flag to gather and give the option to combine the two like: 

```
spake-cli beta gather --init
```
