### PR TITLE
Some tweaks to TranslateArgs + Add key checks to source and target HashMaps

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -15,7 +15,7 @@ pub struct Key {
     pub translate: Option<bool>, // whether or not the string should be translated
 }
 
-pub fn get_json(filepath: String) -> Result<HashMap<String, Key>, Error> {
+pub fn from_json(filepath: String) -> Result<HashMap<String, Key>, Error> {
     let mut file = File::open(filepath)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
@@ -28,13 +28,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_json() {
-        let json = get_json("./tests/test.json".to_string()).unwrap();
+    fn test_from_json() {
+        let json = from_json("./tests/test.json".to_string()).unwrap();
         assert_eq!(json["test_key"].string, "test_value");
     }
     #[test]
     fn test_to_be_skipped() {
-        let json = get_json("./tests/test.json".to_string()).unwrap();
+        let json = from_json("./tests/test.json".to_string()).unwrap();
 
         assert_eq!(json["ToBeSkipped"].translate, Some(false));
     }

--- a/src/gather/gather.rs
+++ b/src/gather/gather.rs
@@ -1,7 +1,7 @@
 // gather.rs
 use base64::{engine::general_purpose, Engine};
 use reqwest::Client;
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{error, fs};
 
 use url::Url;

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,10 +68,10 @@ struct TranslateArgs {
     api_key: String,
 
     #[arg(short, long, default_value = "es")]
-    target_language: Option<translate::models::ValidTargetLanguages>,
+    target_language: translate::models::ValidTargetLanguages,
 
     #[arg(short, long, default_value = "en")]
-    source_language: Option<translate::models::ValidSourceLanguages>,
+    source_language: translate::models::ValidSourceLanguages,
 
     #[arg(long, default_value=params::PRODUCTION_ENDPOINT)]
     host: Option<String>,
@@ -89,11 +89,10 @@ async fn main() {
                 return;
             }
 
-            let target_language_argument = args.target_language.as_ref().unwrap();
-            let target_file_path = format!("strings/strings_{:#?}.json", target_language_argument);
+            let target_language = args.target_language;
+            let source_language = args.source_language;
 
-            let target_language = target_language_argument;
-            let source_language = args.source_language.as_ref().unwrap();
+            let target_file_path = format!("strings/strings_{:#?}.json", target_language);
 
             let api_key = &args.api_key;
 
@@ -119,8 +118,8 @@ async fn main() {
                         let translation_request =
                             translate::translation_request::TranslationRequest {
                                 text: value.string.clone(),
-                                from_language: *source_language,
-                                to_language: *target_language,
+                                from_language: source_language,
+                                to_language: target_language,
                             };
 
                         let translation = translate::translate::translate_string(

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,10 +163,17 @@ async fn main() {
 
             if !src_keys.eq(&tgt_keys) {
                 println!("Key mismatch between translation source and target");
+
                 let src_diff = src_keys.difference(&tgt_keys);
                 let tgt_diff = tgt_keys.difference(&src_keys);
-                println!("Mismatched keys in source: {:?}", src_diff);
-                println!("Mismatched keys in target: {:?}", tgt_diff);
+
+                if src_diff.clone().count() > 0 {
+                    println!("Extra keys in source: {:?}", src_diff);
+                }
+
+                if tgt_diff.clone().count() > 0 {
+                    println!("Extra keys in target: {:?}", tgt_diff);
+                }
             }
 
             let target_file = target_file_path.to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,6 +155,12 @@ async fn main() {
                 )
                 .await;
 
+            // TODO: make this check more informative by factoring out into a helper and
+            // printing which keys are missing or extraneous
+            if !q.keys().eq(to_translate.keys()) {
+                println!("Key mismatch between translation source and target")
+            }
+
             let target_file = target_file_path.to_string();
             let json = match serde_json::to_string_pretty(&q) {
                 Ok(json) => json,


### PR DESCRIPTION
[Ticket](https://www.notion.so/CLI-needs-to-check-that-len-input-len-output-9190735a475045d3b9bfc07906bb2a37)

Note: I want to add a deeper check that informs which keys are extraneous from either HashMap, but it seems to be extremely hairy with a mutable `String` key as opposed to a `&str` key.

`String`
<img width="787" alt="Screen Shot 2023-01-18 at 4 39 54 PM" src="https://user-images.githubusercontent.com/18371085/213328777-668b9472-cc50-49fe-b73d-09b96e1f39ff.png">

`&str`
<img width="891" alt="Screen Shot 2023-01-18 at 4 40 03 PM" src="https://user-images.githubusercontent.com/18371085/213328795-aaa6ee6e-3e9f-4198-9853-6844a59afc96.png">

