### PR TITLE
Reduced multithreading

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ async fn main() {
                         (key, translation)
                     }
                 })
-                .buffer_unordered(9);
+                .buffer_unordered(1);
 
             let q = translation_result
                 .fold(


### PR DESCRIPTION
Per the slack convo, reducing the number of threads the CLI generates to reduce impact on the backend when a model hasn't loaded. We can make the system more robust in the future. 