### PR TITLE
translation quality score report added to CLI output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +948,7 @@ version = "0.0.0"
 dependencies = [
  "base64 0.21.0",
  "clap",
+ "colored",
  "fancy-regex",
  "futures",
  "htmlstream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 base64 = "0.21.0"
 clap = { version = "4.0.18", features = ["derive", "env"] }
+colored = "2.0.0"
 fancy-regex = "0.10.0"
 futures = "0.3.25"
 htmlstream = "0.1.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,8 +79,8 @@ struct TranslateArgs {
     host: Option<String>,
 }
 
-const CUTOFF_HIGH: u32 = 0.6;
-const CUTOFF_MID: u32 = 0.4;
+const CUTOFF_HIGH: f64 = 0.6;
+const CUTOFF_MID: f64 = 0.4;
 
 #[tokio::main]
 async fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::io::Write;
 use std::path::Path;
 
+use colored::*;
 use clap::{Args, Parser, Subcommand};
 
 use futures::{stream, StreamExt};
@@ -142,24 +143,37 @@ async fn main() {
                 })
                 .buffer_unordered(1);
 
-            let q = translation_result
+            // Take each key-value pair from translation_result and insert it into the output hashmap
+            // while maintaining a bucketed count of translation quality scores
+            let (q, good_count, okay_count, poor_count) = translation_result
                 .fold(
-                    destination_hash_map,
-                    |mut destination_hash_map, (key, value)| async {
+                    (destination_hash_map, 0, 0, 0),
+                    |(mut destination_hash_map, mut good_count, mut okay_count, mut poor_count),
+                    (key, value)| async move {
                         let translation = match value {
                             Ok(translation) => translation,
                             Err(error) => {
                                 println!("Error translating string: {}", error);
-                                return destination_hash_map;
+                                return (destination_hash_map, good_count, okay_count, poor_count);
                             }
                         };
+
+                        if translation.quality_score > 0.6 {
+                            good_count += 1;
+                        } else if translation.quality_score >= 0.4 {
+                            okay_count += 1;
+                        } else {
+                            poor_count += 1;
+                        }
+
                         let translated_result = file::Key {
                             string: translation.text,
                             example_keys: None,
                             translate: None,
                         };
+
                         destination_hash_map.insert(key, translated_result);
-                        destination_hash_map
+                        (destination_hash_map, good_count, okay_count, poor_count)
                     },
                 )
                 .await;
@@ -195,6 +209,12 @@ async fn main() {
                 Ok(_) => println!("Successfully wrote to file"),
                 Err(error) => println!("Error writing to file: {}, ", error),
             }
+
+            println!("\nQuality Report:");
+            println!("  {}", format!("{} string(s) with high quality translations", good_count).green());
+            println!("  {}", format!("{} string(s) with mid quality translations", okay_count).yellow());
+            println!("  {}", format!("{} string(s) that we straight up hallucinated", poor_count).red());
+            println!("\nClick here for more details: {}\n", "https://spake.uncommon.industries/dashboard/".blue().underline());
         }
         Commands::Beta(beta) => match beta {
             Beta::Gather(args) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,9 @@ struct TranslateArgs {
     host: Option<String>,
 }
 
+const CUTOFF_HIGH: u32 = 0.6;
+const CUTOFF_MID: u32 = 0.4;
+
 #[tokio::main]
 async fn main() {
     let cli = CLI::parse();
@@ -158,9 +161,9 @@ async fn main() {
                             }
                         };
 
-                        if translation.quality_score > 0.6 {
+                        if translation.quality_score > CUTOFF_HIGH {
                             good_count += 1;
-                        } else if translation.quality_score >= 0.4 {
+                        } else if translation.quality_score >= CUTOFF_MID {
                             okay_count += 1;
                         } else {
                             poor_count += 1;

--- a/src/translate/translation_response.rs
+++ b/src/translate/translation_response.rs
@@ -4,4 +4,5 @@ use serde::{Deserialize, Serialize};
 pub struct TranslationResponse {
     // The translated text.
     pub text: String,
+    pub quality_score: f64,
 }


### PR DESCRIPTION
[Ticket](https://www.notion.so/b415bd241be74795ba30674d62002b76?v=0f9bc8e85e7c4361a69636656fc40d04&p=90d06183824f41559618867b9d13be4f&pm=s)

Accompanying backend PR: https://github.com/UncommonIndustries/uncommonSpake-Backend/pull/63

![Screen Shot 2023-02-06 at 9 57 39 PM](https://user-images.githubusercontent.com/18371085/217138256-2ce005cd-dca7-4277-9a2d-b1bb725e4443.png)
